### PR TITLE
Make seedless test deterministic

### DIFF
--- a/tests/basemath_analysis/test_basemath.py
+++ b/tests/basemath_analysis/test_basemath.py
@@ -170,7 +170,7 @@ def test_seed_not_provided():
     #  zero but less than the total requirement risks losing the 'coin flip' to determine whether we crossed the line
     #  (since we don't control the seed in this test), so we set it to zero to keep the test deterministic
     assert basemath.evaluate_experiment(0, 0, 0, 0) == 0
-    # And now we evaluate with all the samples at once, again deterministic
+    # And now we evaluate with >=required_samples, again deterministic
     assert basemath.evaluate_experiment(0, -10, 0, 50) == -1
 
 

--- a/tests/basemath_analysis/test_basemath.py
+++ b/tests/basemath_analysis/test_basemath.py
@@ -166,8 +166,12 @@ def test_seed_not_provided():
     """
     basemath = BaseMathsTest(0.3, 0.9, 0.05, 0.2)
     assert basemath.required_samples == 42
-    assert basemath.evaluate_experiment(0, -1, 0, 10) == 0
-    assert basemath.evaluate_experiment(-1, -10, 10, 40) == -1
+    # First evaluation to show that the experiment starts inconclusive. Using any number of samples lower than
+    #  the total requirement risks losing the 'coin flip' to determine whether we crossed the line (since we don't
+    #  control the seed in this test), so we set it to zero to keep the test deterministic
+    assert basemath.evaluate_experiment(0, 0, 0, 0) == 0
+    # And now we evaluate with all the samples at once, again deterministic
+    assert basemath.evaluate_experiment(0, -10, 0, 50) == -1
 
 
 def test_all_zeros_in_experiment_evaluation():

--- a/tests/basemath_analysis/test_basemath.py
+++ b/tests/basemath_analysis/test_basemath.py
@@ -166,9 +166,9 @@ def test_seed_not_provided():
     """
     basemath = BaseMathsTest(0.3, 0.9, 0.05, 0.2)
     assert basemath.required_samples == 42
-    # First evaluation to show that the experiment starts inconclusive. Using any number of samples lower than
-    #  the total requirement risks losing the 'coin flip' to determine whether we crossed the line (since we don't
-    #  control the seed in this test), so we set it to zero to keep the test deterministic
+    # First evaluation to show that the experiment starts inconclusive. Using a number of samples that's greater than
+    #  zero but less than the total requirement risks losing the 'coin flip' to determine whether we crossed the line
+    #  (since we don't control the seed in this test), so we set it to zero to keep the test deterministic
     assert basemath.evaluate_experiment(0, 0, 0, 0) == 0
     # And now we evaluate with all the samples at once, again deterministic
     assert basemath.evaluate_experiment(0, -10, 0, 50) == -1


### PR DESCRIPTION
We hit a rare issue in the CI run [here](https://github.com/getyourguide/basemath/actions/runs/12964623091/job/36163509376) -- one test, `test_seed_not_provided`, failed. This didn't have anything to do with the commit, though -- instead, it's an issue with the test. We call `evaluate_experiment` with a small number of samples and -1 overall successes, and this leads to us doing the 'coin flip' to check whether this test experiment might have 'crossed the line'. In this case there's a small (~1%) chance for us to 'fail' the coin flip and get a different result than we normally expect in the test, and that's what happened here. 

We avoid this in other tests by setting the seed, but this is the one test where we deliberately don't do that and test the behaviour. So, the fix is to make the test deterministic in other ways. This PR helps us bypass the coin flip by making sure the probability is zero in our first call (by logging no samples at all) and then all the required samples at once in the second call. 